### PR TITLE
Added link to CKAD practice challenges on Katacoda.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Good resources for being prepared to take the exam:
 * Matthew Palmer, "[CKAD Exam Guide](https://matthewpalmer.net/kubernetes-app-developer/articles/ckad-exam-guide.html)"
 * David Nguyen, "[A Few Tips to Prepare for Your CKAD Exam](https://pnguyen.io/posts/ckad-tips/)"
 * Katie Gamanji on Medium, "[How I Passed My CKAD with 97%](https://medium.com/@kgamanji/how-i-passed-my-ckad-with-97-6b54dcffa72f)"
+* Liptan Biswas on Dev.to, "[CKAD Practice Questions](https://dev.to/liptanbiswas/ckad-practice-questions-4mpn)"
 
 ## Additional K8s References and Training
 


### PR DESCRIPTION
A set of practice challenges to prepare for the CNCF Certified Kubernetes Application Developer exam built using Katacoda in already provisioned and running Kubernetes cluster. Tests have verifications in place as well.

PS: They are authored by me.